### PR TITLE
BOOK-003: Adding test coverage badge to README from CodeCov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🧑🏽‍💻 Project `bookshop` [![Continuous Integration Pipeline](https://github.com/zatarain/bookshop/actions/workflows/pipeline.yml/badge.svg)](https://github.com/zatarain/bookshop/actions/workflows/pipeline.yml)
+# 🧑🏽‍💻 Project `bookshop` [![Continuous Integration Pipeline](https://github.com/zatarain/bookshop/actions/workflows/pipeline.yml/badge.svg)](https://github.com/zatarain/bookshop/actions/workflows/pipeline.yml) [![codecov](https://codecov.io/github/zatarain/bookshop/branch/main/graph/badge.svg?token=BQRBXEN0PR)](https://codecov.io/github/zatarain/bookshop)
 This project intents to be an example to use it as a playground for an API development of a book shop implemented in Golang.
 
 ## ☑️ Requirements


### PR DESCRIPTION
## 🌟 Description
These changes add the badge from CodeCov for the test coverage in the README.md

## ✅ Testing
Manual testing with Markdown visualizer in VSCode and GitHub website.

## 🖼️ Evidence
Following is the VSCode preview:
![image](https://github.com/zatarain/bookshop/assets/539783/e2700efe-cc33-4035-9329-8024f84138b6)

And also the GitHub website:
![image](https://github.com/zatarain/bookshop/assets/539783/e7709801-185c-453c-badf-24e5cab04eba)
